### PR TITLE
wrap 'writeConcern' around insert/update options

### DIFF
--- a/src/Database/Mongo/Options.purs
+++ b/src/Database/Mongo/Options.purs
@@ -23,7 +23,7 @@ defaultInsertOptions = InsertOptions
 
 instance encodeJsonInsertOptions :: WriteForeign InsertOptions where
   writeImpl (InsertOptions {writeConcern, journaled}) =
-    write { w: writeConcern, j: journaled }
+    write { writeConcern: { w: writeConcern, j: journaled } }
 
 -- | Typed options for updating documents into a collection
 newtype UpdateOptions = UpdateOptions
@@ -41,4 +41,4 @@ defaultUpdateOptions = UpdateOptions
 
 instance encodeJsonUpdateOptions :: WriteForeign UpdateOptions where
   writeImpl (UpdateOptions o) =
-    write { w: o.writeConcern, j: o.journaled, upsert: o.upsert }
+    write { writeConcern: { w: o.writeConcern, j: o.journaled, upsert: o.upsert } }


### PR DESCRIPTION
removes deprecated warning from mongodb

without this wrapper you get a warning like this:

> (node:28432) [MONGODB DRIVER] Warning: Top-level use of w, wtimeout, j, and fsync is deprecated. Use writeConcern instead.
