### PR TITLE
provide setters to change Insert/Update options

### DIFF
--- a/src/Database/Mongo/Options.purs
+++ b/src/Database/Mongo/Options.purs
@@ -1,8 +1,13 @@
 module Database.Mongo.Options
   ( InsertOptions()
   , defaultInsertOptions
+  , setInsertWriteConcern
+  , setInsertJournaled
   , UpdateOptions()
   , defaultUpdateOptions
+  , setUpdateWriteConcern
+  , setUpdateJournaled
+  , setUpdateUpsert
   ) where
 
 import Data.Maybe (Maybe(..))
@@ -21,6 +26,12 @@ defaultInsertOptions = InsertOptions
   , journaled    : Just false
   }
 
+setInsertWriteConcern :: WriteConcern -> InsertOptions -> InsertOptions
+setInsertWriteConcern wc (InsertOptions io) = InsertOptions (io { writeConcern = Just wc})
+
+setInsertJournaled :: Maybe Boolean -> InsertOptions -> InsertOptions
+setInsertJournaled j (InsertOptions io) = InsertOptions (io { journaled = j })
+
 instance encodeJsonInsertOptions :: WriteForeign InsertOptions where
   writeImpl (InsertOptions {writeConcern, journaled}) =
     write { w: writeConcern, j: journaled }
@@ -38,6 +49,15 @@ defaultUpdateOptions = UpdateOptions
   , journaled    : Just false
   , upsert       : Just false
   }
+  
+setUpdateWriteConcern :: WriteConcern -> UpdateOptions -> UpdateOptions
+setUpdateWriteConcern wc (UpdateOptions uo) = UpdateOptions (uo { writeConcern = Just wc})
+
+setUpdateJournaled :: Maybe Boolean -> UpdateOptions -> UpdateOptions
+setUpdateJournaled j (UpdateOptions uo) = UpdateOptions (uo { journaled = j })
+
+setUpdateUpsert :: Maybe Boolean -> UpdateOptions -> UpdateOptions
+setUpdateUpsert u (UpdateOptions uo) = UpdateOptions (uo { upsert = u })
 
 instance encodeJsonUpdateOptions :: WriteForeign UpdateOptions where
   writeImpl (UpdateOptions o) =


### PR DESCRIPTION
right now there is no way to change the options, as the data-constructor is not public - this PR would allow for something like

```purescript
defaultInsertOptions # setInsertWriteConcern oneAck
```
